### PR TITLE
Add .5rem of spacing when the sender changes and remove space when sender is same

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "stop": "yarn workspace server stop",
     "restart": "yarn workspace server restart",
     "logs": "yarn workspace server logs"
+  },
+  "dependencies": {
+    "connect-history-api-fallback": "^1.6.0"
   }
 }

--- a/packages/client-web/src/components/ChannelMessage.vue
+++ b/packages/client-web/src/components/ChannelMessage.vue
@@ -18,7 +18,8 @@
       :class="{
         'ml-auto flex-row-reverse space-x-reverse': sentByMe && messageSides,
         'mb-2': lastFromSender,
-      }"
+        '-mb-0.5': !lastFromSender,
+        }"
     >
       <div class="w-8 h-8 self-end relative">
         <UserAvatar

--- a/packages/client-web/src/components/ChannelMessage.vue
+++ b/packages/client-web/src/components/ChannelMessage.vue
@@ -17,8 +17,8 @@
       class="flex group items-center space-x-2"
       :class="{
         'ml-auto flex-row-reverse space-x-reverse': sentByMe && messageSides,
+        'mb-2': lastFromSender,
       }"
-      v-else
     >
       <div class="w-8 h-8 self-end relative">
         <UserAvatar


### PR DESCRIPTION
This has been idiot-tested by 4 testers and this was the one option that was not too large and also liked by all of them. It makes reading messages with many people going back and fourth much easier.